### PR TITLE
Kusto ingestion service client streaming

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -1,4 +1,3 @@
-//
 package main
 
 import (
@@ -24,7 +23,7 @@ func (client *KustoIngestionClient) SendAsync(msg PubsubMsg) error {
 
 	functionKey := os.Getenv("FUNCTIONKEY")
 	if functionKey == "" {
-		log.Fatalf("Failed to set function key")
+		log.Fatalf("Failed to set function key env var")
 	}
 
 	requestUri := targetUri + "?code=" + functionKey

--- a/clients.go
+++ b/clients.go
@@ -1,0 +1,57 @@
+//
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+type KustoIngestionClient struct{}
+
+type RawMsgs struct {
+	Records []PubsubMsg `json:"records,omitempty"`
+}
+
+func (client *KustoIngestionClient) SendAsync(msg PubsubMsg) error {
+	targetUri := os.Getenv("TARGETURI")
+	if targetUri == "" {
+		log.Fatalf("Failed to set target uri env var")
+	}
+
+	functionKey := os.Getenv("FUNCTIONKEY")
+	if functionKey == "" {
+		log.Fatalf("Failed to set function key")
+	}
+
+	requestUri := targetUri + "?code=" + functionKey
+
+	rawMsgs := RawMsgs{
+		Records: []PubsubMsg{msg},
+	}
+
+	buf, err := json.Marshal(rawMsgs)
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+
+	var resp *http.Response
+	for i := 0; i < 3; i++ {
+		resp, err = http.Post(requestUri, "application/json", bytes.NewBuffer(buf))
+		if err == nil {
+			break
+		}
+		fmt.Println(err)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Response Status:", resp.Status)
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,9 @@ type PubsubMsg struct {
 	ResourceNamespace     string            `json:"resourceNamespace,omitempty"`
 	ResourceName          string            `json:"resourceName,omitempty"`
 	ResourceLabels        map[string]string `json:"resourceLabels,omitempty"`
+    // Additional Metadata for benchmarking
+    BrokerName            string            `json:"brokerName,omitempty"`
+    Timestamp             string            `json:"timestamp,omitempty"`
 }
 
 var sub = &common.Subscription{
@@ -56,7 +59,7 @@ func main() {
 			duration := endTime.Sub(startTime)
 			log.Printf("Total events received: %d, Time taken: %v", eventCount, duration)
 			panic("test")
-		} 
+		}
 		time.Sleep(20 * time.Second)
 	}
 }
@@ -65,6 +68,8 @@ var eventCount int
 var startTime time.Time
 var endTime time.Time
 var flag bool
+
+var kustoIngestionClient = KustoIngestionClient{}
 
 func eventHandler(ctx context.Context, e *common.TopicEvent) (retry bool, err error) {
 	var msg PubsubMsg
@@ -78,10 +83,16 @@ func eventHandler(ctx context.Context, e *common.TopicEvent) (retry bool, err er
 	if flag {
 		startTime = time.Now() // record start time
 		flag = false
-	} 
-	
+	}
+
+	err = kustoIngestionClient.SendAsync(msg)
+	if err != nil {
+		// Continue if ingestion error, to do track count of these
+		log.Printf("ingestion error %v", err)
+	}
+
 	eventCount++
 	log.Printf("%#v", eventCount)
-	
+
 	return false, nil
 }

--- a/main.go
+++ b/main.go
@@ -30,9 +30,9 @@ type PubsubMsg struct {
 	ResourceNamespace     string            `json:"resourceNamespace,omitempty"`
 	ResourceName          string            `json:"resourceName,omitempty"`
 	ResourceLabels        map[string]string `json:"resourceLabels,omitempty"`
-    // Additional Metadata for benchmarking
-    BrokerName            string            `json:"brokerName,omitempty"`
-    Timestamp             string            `json:"timestamp,omitempty"`
+	// Additional Metadata for benchmarking
+	BrokerName            string            `json:"brokerName,omitempty"`
+	Timestamp             string            `json:"timestamp,omitempty"`
 }
 
 var sub = &common.Subscription{
@@ -59,7 +59,7 @@ func main() {
 			duration := endTime.Sub(startTime)
 			log.Printf("Total events received: %d, Time taken: %v", eventCount, duration)
 			panic("test")
-		}
+		} 
 		time.Sleep(20 * time.Second)
 	}
 }
@@ -93,6 +93,6 @@ func eventHandler(ctx context.Context, e *common.TopicEvent) (retry bool, err er
 
 	eventCount++
 	log.Printf("%#v", eventCount)
-
+	
 	return false, nil
 }

--- a/sub.yaml
+++ b/sub.yaml
@@ -54,3 +54,7 @@ spec:
         env:
         - name: NUMBER
           value: "1000"
+        - name: TARGETURI
+          value: ""
+        - name: FUNCTIONKEY
+          value: ""


### PR DESCRIPTION
Stream events to Kusto ingestion service to help benchmark dapr/broker. The targeturi/functionkey shared offline and service code hosted privately.